### PR TITLE
Clarify the `-Zmiri-track-pointer-tag` in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,8 +383,8 @@ to Miri failing to detect cases of undefined behavior in a program.
   Borrows "protectors". Specifying this argument multiple times does not overwrite the previous
   values, instead it appends its values to the list. Listing an id multiple times has no effect.
 * `-Zmiri-track-pointer-tag=<tag1>,<tag2>,...` shows a backtrace when a given pointer tag
-  is popped from a borrow stack (which is where the tag becomes invalid and any
-  future use of it will error).  This helps you in finding out why UB is
+  is created or when it is popped from a borrow stack (which is where the tag becomes invalid 
+  and any future use of it will error).  This helps you in finding out why UB is
   happening and where in your code would be a good place to look for it.
   Specifying this argument multiple times does not overwrite the previous
   values, instead it appends its values to the list. Listing a tag multiple times has no effect.


### PR DESCRIPTION
to explicitly say it also tracks tag creation.

Related to https://github.com/rust-lang/miri/pull/2308 / https://github.com/Manishearth/triomphe/issues/38.